### PR TITLE
fix: bootstrap job uses wrong health endpoint

### DIFF
--- a/internal/resources/bootstrap.go
+++ b/internal/resources/bootstrap.go
@@ -107,7 +107,9 @@ else
 fi
 
 # Step 2: Check if instance is already bootstrapped
-HEALTH=$(curl -sS -c "$COOKIE_JAR" -b "$COOKIE_JAR" "$SERVER_URL/api/health" 2>/dev/null) || true
+# Use /api/health/details (authenticated) which includes bootstrapStatus;
+# the plain /api/health endpoint does not return this field.
+HEALTH=$(curl -sS -c "$COOKIE_JAR" -b "$COOKIE_JAR" "$SERVER_URL/api/health/details" 2>/dev/null) || true
 if echo "$HEALTH" | grep -q '"bootstrapStatus":"ready"'; then
   echo "Instance already bootstrapped. Nothing to do."
   rm -f "$COOKIE_JAR"


### PR DESCRIPTION
## Summary
- The bootstrap job checked `/api/health` for `bootstrapStatus` but that field only exists on `/api/health/details` (the authenticated endpoint)
- This caused the "already bootstrapped?" check to always fail, falling through to `bootstrap-ceo` which errors with "Instance already has an admin user"
- The job then hits its backoff limit and reports as Failed, even though the instance is working fine

## Test plan
- [ ] Restart any existing Paperclip instance — bootstrap job should exit 0 with "Instance already bootstrapped"
- [ ] Create a fresh instance — bootstrap job should complete the full flow (sign up → generate invite → accept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)