### PR TITLE
fix: align S3 env var names with server config

### DIFF
--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -274,12 +274,12 @@ func buildEnvVars(instance *paperclipv1alpha1.Instance) []corev1.EnvVar {
 	if instance.Spec.ObjectStorage != nil {
 		os := instance.Spec.ObjectStorage
 		vars = append(vars, corev1.EnvVar{Name: "PAPERCLIP_STORAGE_PROVIDER", Value: "s3"})
-		vars = append(vars, corev1.EnvVar{Name: "PAPERCLIP_S3_BUCKET", Value: os.Bucket})
+		vars = append(vars, corev1.EnvVar{Name: "PAPERCLIP_STORAGE_S3_BUCKET", Value: os.Bucket})
 		if os.Region != "" {
-			vars = append(vars, corev1.EnvVar{Name: "PAPERCLIP_S3_REGION", Value: os.Region})
+			vars = append(vars, corev1.EnvVar{Name: "PAPERCLIP_STORAGE_S3_REGION", Value: os.Region})
 		}
 		if os.Endpoint != "" {
-			vars = append(vars, corev1.EnvVar{Name: "PAPERCLIP_S3_ENDPOINT", Value: os.Endpoint})
+			vars = append(vars, corev1.EnvVar{Name: "PAPERCLIP_STORAGE_S3_ENDPOINT", Value: os.Endpoint})
 		}
 		if os.CredentialsSecretRef != nil {
 			vars = append(vars,


### PR DESCRIPTION
## Summary
The operator set `PAPERCLIP_S3_BUCKET`, `PAPERCLIP_S3_REGION`, `PAPERCLIP_S3_ENDPOINT` but the server config expects `PAPERCLIP_STORAGE_S3_BUCKET`, `PAPERCLIP_STORAGE_S3_REGION`, `PAPERCLIP_STORAGE_S3_ENDPOINT`. S3 object storage was silently broken for all operator-managed instances.

## Test plan
- [ ] Deploy an instance with `spec.objectStorage` configured → verify `PAPERCLIP_STORAGE_S3_*` env vars are set on the statefulset

🤖 Generated with [Claude Code](https://claude.com/claude-code)