### PR TITLE
fix: apply CRD security context override to all Paperclip containers

### DIFF
--- a/internal/resources/bootstrap.go
+++ b/internal/resources/bootstrap.go
@@ -188,16 +188,7 @@ echo "Admin bootstrap finished successfully."
 							ImagePullPolicy: imagePullPolicy(instance),
 							Command:         []string{"/bin/sh", "-c"},
 							Args:            []string{script},
-							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: Ptr(false),
-								RunAsNonRoot:             Ptr(true),
-								SeccompProfile: &corev1.SeccompProfile{
-									Type: corev1.SeccompProfileTypeRuntimeDefault,
-								},
-								Capabilities: &corev1.Capabilities{
-									Drop: []corev1.Capability{"ALL"},
-								},
-							},
+							SecurityContext: paperclipContainerSecurityContext(instance),
 							Env: append(buildEnvVars(instance),
 								corev1.EnvVar{
 									Name:  "ADMIN_EMAIL",

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	paperclipv1alpha1 "github.com/paperclipinc/paperclip-operator/api/v1alpha1"
@@ -198,4 +199,23 @@ func DatabaseSecretName(instance *paperclipv1alpha1.Instance) string {
 // SecretsMasterKeySecretName returns the auto-generated secrets master key secret name.
 func SecretsMasterKeySecretName(instance *paperclipv1alpha1.Instance) string {
 	return instance.Name + "-secrets-master-key"
+}
+
+// paperclipContainerSecurityContext returns the security context for containers
+// running the Paperclip image. If the user has provided a custom security context
+// via the CRD, it is used; otherwise the restricted-PSS-compliant default is returned.
+func paperclipContainerSecurityContext(instance *paperclipv1alpha1.Instance) *corev1.SecurityContext {
+	if instance.Spec.Security.ContainerSecurityContext != nil {
+		return instance.Spec.Security.ContainerSecurityContext
+	}
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: Ptr(false),
+		RunAsNonRoot:             Ptr(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
 }

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -1387,3 +1387,101 @@ func TestNamingConventions(t *testing.T) {
 		})
 	}
 }
+
+func TestContainerSecurityContextOverrideAppliesToAllPaperclipContainers(t *testing.T) {
+	instance := newTestInstance("my-paperclip")
+	instance.Spec.Security.ContainerSecurityContext = &corev1.SecurityContext{
+		AllowPrivilegeEscalation: Ptr(false),
+		RunAsNonRoot:             Ptr(false),
+		RunAsUser:                Ptr(int64(0)),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+			Add:  []corev1.Capability{"SETUID", "SETGID"},
+		},
+	}
+
+	// Main container
+	sts := BuildStatefulSet(instance, nil)
+	mainContainer := sts.Spec.Template.Spec.Containers[0]
+	if *mainContainer.SecurityContext.RunAsNonRoot != false {
+		t.Error("main container: expected RunAsNonRoot=false from CRD override")
+	}
+	if *mainContainer.SecurityContext.RunAsUser != 0 {
+		t.Error("main container: expected RunAsUser=0 from CRD override")
+	}
+
+	// Onboard init container - should also use the CRD override
+	var onboard *corev1.Container
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		if sts.Spec.Template.Spec.InitContainers[i].Name == "onboard" {
+			onboard = &sts.Spec.Template.Spec.InitContainers[i]
+			break
+		}
+	}
+	if onboard == nil {
+		t.Fatal("expected onboard init container")
+	}
+	if *onboard.SecurityContext.RunAsNonRoot != false {
+		t.Error("onboard: expected RunAsNonRoot=false from CRD override")
+	}
+
+	// Bootstrap job
+	instance.Spec.Auth.AdminUser = &paperclipv1alpha1.AdminUserSpec{
+		Email: "admin@test.com",
+		PasswordSecretRef: corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "admin-secret"},
+			Key:                  "password",
+		},
+	}
+	job := BuildBootstrapJob(instance)
+	bootstrapContainer := job.Spec.Template.Spec.Containers[0]
+	if *bootstrapContainer.SecurityContext.RunAsNonRoot != false {
+		t.Error("bootstrap: expected RunAsNonRoot=false from CRD override")
+	}
+}
+
+func TestDefaultSecurityContextOnOnboardAndBootstrap(t *testing.T) {
+	instance := newTestInstance("my-paperclip")
+	// No CRD override - should get restricted PSS defaults
+
+	sts := BuildStatefulSet(instance, nil)
+	var onboard *corev1.Container
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		if sts.Spec.Template.Spec.InitContainers[i].Name == "onboard" {
+			onboard = &sts.Spec.Template.Spec.InitContainers[i]
+			break
+		}
+	}
+	if onboard == nil {
+		t.Fatal("expected onboard init container")
+	}
+	sc := onboard.SecurityContext
+	if *sc.RunAsNonRoot != true {
+		t.Error("onboard: expected default RunAsNonRoot=true")
+	}
+	if *sc.AllowPrivilegeEscalation != false {
+		t.Error("onboard: expected default AllowPrivilegeEscalation=false")
+	}
+	if sc.Capabilities == nil || sc.Capabilities.Drop[0] != "ALL" {
+		t.Error("onboard: expected default drop ALL capabilities")
+	}
+
+	instance.Spec.Auth.AdminUser = &paperclipv1alpha1.AdminUserSpec{
+		Email: "admin@test.com",
+		PasswordSecretRef: corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "admin-secret"},
+			Key:                  "password",
+		},
+	}
+	job := BuildBootstrapJob(instance)
+	bsc := job.Spec.Template.Spec.Containers[0].SecurityContext
+	if *bsc.RunAsNonRoot != true {
+		t.Error("bootstrap: expected default RunAsNonRoot=true")
+	}
+	if *bsc.AllowPrivilegeEscalation != false {
+		t.Error("bootstrap: expected default AllowPrivilegeEscalation=false")
+	}
+}

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -165,20 +165,10 @@ func buildMainContainer(instance *paperclipv1alpha1.Instance) corev1.Container {
 	}
 
 	// Container security context
-	if instance.Spec.Security.ContainerSecurityContext != nil {
-		container.SecurityContext = instance.Spec.Security.ContainerSecurityContext
-	} else {
-		container.SecurityContext = &corev1.SecurityContext{
-			AllowPrivilegeEscalation: Ptr(false),
-			ReadOnlyRootFilesystem:   Ptr(false), // Paperclip needs writable filesystem for node_modules, etc.
-			RunAsNonRoot:             Ptr(true),
-			SeccompProfile: &corev1.SeccompProfile{
-				Type: corev1.SeccompProfileTypeRuntimeDefault,
-			},
-			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{"ALL"},
-			},
-		}
+	container.SecurityContext = paperclipContainerSecurityContext(instance)
+	if container.SecurityContext.ReadOnlyRootFilesystem == nil {
+		container.SecurityContext = container.SecurityContext.DeepCopy()
+		container.SecurityContext.ReadOnlyRootFilesystem = Ptr(false) // Paperclip needs writable filesystem for node_modules, etc.
 	}
 
 	// Multi-replica heartbeat gating: only pod-0 runs the scheduler.
@@ -845,16 +835,7 @@ exit 1
 		Env:             buildEnvVars(instance),
 		EnvFrom:         instance.Spec.EnvFrom,
 		VolumeMounts:    buildVolumeMounts(instance),
-		SecurityContext: &corev1.SecurityContext{
-			AllowPrivilegeEscalation: Ptr(false),
-			RunAsNonRoot:             Ptr(true),
-			SeccompProfile: &corev1.SeccompProfile{
-				Type: corev1.SeccompProfileTypeRuntimeDefault,
-			},
-			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{"ALL"},
-			},
-		},
+		SecurityContext: paperclipContainerSecurityContext(instance),
 	}
 }
 


### PR DESCRIPTION
## Summary
- Extracts a shared `paperclipContainerSecurityContext()` helper that returns the CRD override (`security.containerSecurityContext`) or the restricted-PSS default
- Applies it consistently to the **main container**, **onboard init container**, and **bootstrap job** -- previously only the main container respected the override
- Adds tests verifying both the CRD override flow and the default security context for onboard and bootstrap

## Context
The Paperclip image entrypoint uses `gosu` to drop from root to the `node` user, which requires `runAsNonRoot=false` and privilege capabilities. The operator hardcoded `runAsNonRoot=true` on the onboard init container and bootstrap job with no override mechanism, making Paperclip undeployable on restricted PodSecurity clusters even with CRD overrides.

The companion fix in the Paperclip image (paperclipai/paperclip#2904) skips `gosu` when already running as the target user, making the operator's default security context correct. This PR ensures the override path works for all containers when needed.

Closes #45

## Test plan
- [x] `make test` -- all unit + envtest integration tests pass
- [x] `make lint` -- zero issues
- [ ] Deploy on a restricted PSS cluster with the fixed image to verify pods start cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)