### PR TITLE
chore: bump Go toolchain and golangci-lint to support Go 1.25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
   REGISTRY: ghcr.io
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 Go-based Kubernetes operator for managing Paperclip instances (the open-source AI agent orchestration platform), built with controller-runtime (kubebuilder). CRD API group is `paperclip.ai`, version `v1alpha1`.
 
 - **Module:** `github.com/paperclipinc/paperclip-operator`
-- **Go version:** 1.24
+- **Go version:** 1.25
 - **GitHub:** `paperclipinc/paperclip-operator` (GHCR org: `paperclipinc`)
 
 ## Commands

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.24-alpine AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.25-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETPLATFORM

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.18.0
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
-GOLANGCI_LINT_VERSION ?= v2.1.0
+GOLANGCI_LINT_VERSION ?= v2.11.4
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.


### PR DESCRIPTION
## Summary

Bumps the pinned Go toolchain from 1.24 to 1.25 and `golangci-lint` from `v2.1.0` to `v2.11.4`.

- `.github/workflows/ci.yaml`: `GO_VERSION` `1.24` to `1.25`
- `Dockerfile`: `golang:1.24-alpine` to `golang:1.25-alpine`
- `Makefile`: `GOLANGCI_LINT_VERSION` `v2.1.0` to `v2.11.4`
- `CLAUDE.md`: documented Go version `1.24` to `1.25`

## Why

`golangci-lint v2.1.0` was built against Go 1.24 and refuses to lint code targeted at a newer Go version:

> `can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)`

This blocks any dependency bump that raises the `go` directive in `go.mod` past 1.24. The immediate motivation is #50 (`otel/sdk` 1.40 to 1.43, which requires Go 1.25), but this affects every future bump in that direction. Bumping the toolchain pins and `golangci-lint` unblocks #50 and anything like it that follows.

## Test plan

- [x] `make lint` (0 issues with v2.11.4 installed)
- [x] `go build ./...` clean
- [x] `go test ./internal/resources/` green
- [ ] Full CI on this PR (envtest `make test`, E2E, security scan)
- [ ] After merge: rebase #50, confirm CI passes, auto-merge it

🤖 Generated with [Claude Code](https://claude.com/claude-code)