### PR TITLE
chore(ci): bump golangci-lint-action pin to v2.11.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.0
+          version: v2.11.4
           args: --timeout=5m
 
   reconcile-guard:


### PR DESCRIPTION
## Summary

Bumps the hardcoded `version` input of `golangci/golangci-lint-action@v7` in the Lint job from `v2.1.0` to `v2.11.4`.

## Why

#56 bumped `GOLANGCI_LINT_VERSION` in the `Makefile` (so developers running `make lint` locally get a Go-1.25-compatible binary) but the CI Lint job uses `golangci/golangci-lint-action` with its own `version` input, independent of the Makefile. I missed that input, so CI kept failing on any PR whose `go.mod` targets Go 1.25:

> `can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)`

Matching the action pin to the Makefile pin unblocks #50 (`otel/sdk` 1.43) and any future PR that raises the `go` directive.

## Test plan

- [x] Same `v2.11.4` already verified on #56 via local `make lint` (0 issues).
- [ ] CI Lint on this PR, confirming the action is now built against Go 1.25.
- [ ] After merge, rebase #50 and confirm its Lint job passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)