### PR TITLE
fix(ci): drop --remote from gh repo fork in OperatorHub submission

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -62,8 +62,11 @@ jobs:
           # Configure gh as git credential helper so git push works with the PAT
           gh auth setup-git
 
-          # Clone the community-operators repo (fork is auto-created by gh)
-          gh repo fork k8s-operatorhub/community-operators --clone=true --remote=true -- community-operators
+          # Clone the community-operators repo (fork is auto-created by gh).
+          # --remote is incompatible with passing a repo argument in modern gh;
+          # gh repo fork --clone already sets up origin=fork and upstream=canonical
+          # in the new clone.
+          gh repo fork k8s-operatorhub/community-operators --clone=true -- community-operators
           cd community-operators
 
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

Removes the `--remote=true` flag from the `gh repo fork` call in `.github/workflows/operatorhub.yaml`. Modern `gh` CLI rejects `--remote` when a repository argument is also passed, with:

> `the --remote flag is unsupported when a repository argument is provided`

## Why

The OperatorHub submission workflow has silently failed on every release since **v0.10.2** (2026-03-31), so no bundle PR has been opened at `k8s-operatorhub/community-operators` for any of v0.10.2, v0.10.3, v0.10.4, v0.10.5, or v0.11.0. The listing at https://operatorhub.io/operator/paperclip-operator is therefore stuck on whatever bundle was last successfully submitted (the original v0.1.0 with the placeholder logo, `capabilities: Full Lifecycle`, and the personal maintainer email).

`--remote` was redundant here anyway. `gh repo fork --clone` with a repo argument already:

- Creates the fork on GitHub (idempotent)
- Clones it into the target directory
- Auto-configures `origin` pointing at the fork and `upstream` pointing at the canonical repo

Which is exactly what the subsequent `git fetch upstream main` / `git reset --hard upstream/main` relies on.

## Test plan

- [x] YAML shell diff inspected.
- [ ] Workflow CI on this PR (no workflow execution happens from PR events for `release.published`, so this PR can only be validated by re-triggering the workflow post-merge).
- [ ] After merge, manually trigger the workflow for v0.11.0:
  ```
  gh workflow run "OperatorHub Submission" -f tag=v0.11.0
  ```
  and confirm a PR is opened at `k8s-operatorhub/community-operators`.
- [ ] Backfill v0.10.2..v0.10.5 if desired (probably not worth it; v0.11.0 supersedes them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)