### PR TITLE
chore: finish paperclipinc migration (NOTICE attribution)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,4 +2,4 @@ Paperclip Kubernetes Operator
 Copyright 2026 Paperclip AI
 
 This product includes software developed at Paperclip AI
-(https://github.com/openclaw-rocks).
+(https://github.com/paperclipinc).


### PR DESCRIPTION
Final straggler from the openclaw-rocks/stubbi -> paperclipinc migration: `NOTICE` still attributed the project to `github.com/openclaw-rocks`. Everything else (Go module, image refs, Helm chart, README, CLAUDE.md) was already migrated on main.

Surfaced while investigating #61: the repo references are all correct, but no image/chart was ever published to the `paperclipinc` GHCR org (the only published artifacts live under the `stubbi` user namespace). That publish step is tracked separately.