### PR TITLE
ci(operatorhub): pin image digest, add relatedImages, submit to RedHat catalog

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -33,12 +33,20 @@ jobs:
           TAG="${{ steps.version.outputs.tag }}"
           BUNDLE_DIR="submission/operators/paperclip-operator/${VERSION}"
 
+          # Resolve the published image to an immutable digest reference so the
+          # submitted bundle is pinned (OLM best practice). Fall back to the
+          # floating tag if the digest cannot be resolved (e.g. registry hiccup).
+          IMG="ghcr.io/paperclipinc/paperclip-operator"
+          DIGEST="$(docker buildx imagetools inspect "${IMG}:${TAG}" --format '{{ .Manifest.Digest }}' 2>/dev/null || true)"
+          if [ -n "${DIGEST}" ]; then IMG_REF="${IMG}@${DIGEST}"; else IMG_REF="${IMG}:${TAG}"; fi
+          echo "Pinning image to: ${IMG_REF}"
+
           mkdir -p "${BUNDLE_DIR}/manifests" "${BUNDLE_DIR}/metadata"
 
           # Copy and version the CSV
           sed \
             -e "s/paperclip-operator\.v[0-9]\+\.[0-9]\+\.[0-9]\+/paperclip-operator.v${VERSION}/g" \
-            -e "s|ghcr.io/paperclipinc/paperclip-operator:v[0-9]\+\.[0-9]\+\.[0-9]\+|ghcr.io/paperclipinc/paperclip-operator:${TAG}|g" \
+            -e "s|ghcr.io/paperclipinc/paperclip-operator:v[0-9]\+\.[0-9]\+\.[0-9]\+|${IMG_REF}|g" \
             -e "s/createdAt: .*/createdAt: \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"/" \
             -e "s/^  version: [0-9]\+\.[0-9]\+\.[0-9]\+/  version: ${VERSION}/" \
             bundle/manifests/paperclip-operator.v*.clusterserviceversion.yaml \
@@ -107,6 +115,116 @@ jobs:
           if ! gh pr view "${FORK_OWNER}:${BRANCH}" --repo k8s-operatorhub/community-operators --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
             gh pr create \
               --repo k8s-operatorhub/community-operators \
+              --head "${FORK_OWNER}:${BRANCH}" \
+              --title "operator paperclip-operator (${VERSION})" \
+              --body "$(cat <<EOF
+          ### Update to paperclip-operator
+
+          **Version:** ${VERSION}
+          **Operator:** [Paperclip Kubernetes Operator](https://github.com/paperclipinc/paperclip-operator)
+
+          #### Changes
+          See [release notes](https://github.com/paperclipinc/paperclip-operator/releases/tag/v${VERSION}).
+
+          #### Testing
+          - CI tests pass on the source repository
+          - Container image is published and signed at \`ghcr.io/paperclipinc/paperclip-operator:v${VERSION}\`
+          EOF
+          )"
+          else
+            echo "PR already exists for ${FORK_OWNER}:${BRANCH} - branch was force-pushed with updated content"
+          fi
+
+  submit-redhat:
+    name: Submit to RedHat community-operators-prod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: version
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.version.outputs.tag }}
+
+      - name: Prepare bundle
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
+          BUNDLE_DIR="submission/operators/paperclip-operator/${VERSION}"
+
+          # Resolve the published image to an immutable digest reference so the
+          # submitted bundle is pinned (OLM best practice). Fall back to the
+          # floating tag if the digest cannot be resolved (e.g. registry hiccup).
+          IMG="ghcr.io/paperclipinc/paperclip-operator"
+          DIGEST="$(docker buildx imagetools inspect "${IMG}:${TAG}" --format '{{ .Manifest.Digest }}' 2>/dev/null || true)"
+          if [ -n "${DIGEST}" ]; then IMG_REF="${IMG}@${DIGEST}"; else IMG_REF="${IMG}:${TAG}"; fi
+          echo "Pinning image to: ${IMG_REF}"
+
+          mkdir -p "${BUNDLE_DIR}/manifests" "${BUNDLE_DIR}/metadata"
+
+          # Copy and version the CSV
+          sed \
+            -e "s/paperclip-operator\.v[0-9]\+\.[0-9]\+\.[0-9]\+/paperclip-operator.v${VERSION}/g" \
+            -e "s|ghcr.io/paperclipinc/paperclip-operator:v[0-9]\+\.[0-9]\+\.[0-9]\+|${IMG_REF}|g" \
+            -e "s/createdAt: .*/createdAt: \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"/" \
+            -e "s/^  version: [0-9]\+\.[0-9]\+\.[0-9]\+/  version: ${VERSION}/" \
+            bundle/manifests/paperclip-operator.v*.clusterserviceversion.yaml \
+            > "${BUNDLE_DIR}/manifests/paperclip-operator.v${VERSION}.clusterserviceversion.yaml"
+
+          # Copy CRD and metadata as-is
+          cp bundle/manifests/paperclip.inc_instances.yaml "${BUNDLE_DIR}/manifests/" 2>/dev/null || \
+            cp config/crd/bases/paperclip.inc_instances.yaml "${BUNDLE_DIR}/manifests/"
+          cp bundle/metadata/annotations.yaml "${BUNDLE_DIR}/metadata/"
+
+          echo "Bundle prepared at ${BUNDLE_DIR}:"
+          find "${BUNDLE_DIR}" -type f
+
+      - name: Fork and submit to community-operators-prod
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BRANCH="paperclip-operator-v${VERSION}"
+
+          # Configure gh as git credential helper so git push works with the PAT
+          gh auth setup-git
+
+          # Clone the community-operators-prod repo (fork is auto-created by gh).
+          # gh repo fork --clone already sets up origin=fork and upstream=canonical
+          # in the new clone.
+          gh repo fork redhat-openshift-ecosystem/community-operators-prod --clone=true -- community-operators-prod
+          cd community-operators-prod
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Sync fork with upstream to avoid stale-branch CI failures
+          git fetch upstream main
+          git reset --hard upstream/main
+
+          git checkout -b "${BRANCH}"
+
+          # Copy prepared bundle. RedHat uses a different review model, so we do
+          # NOT write a ci.yaml here (unlike the k8s community-operators job).
+          mkdir -p operators/paperclip-operator
+          cp -r ../submission/operators/paperclip-operator/${VERSION} operators/paperclip-operator/${VERSION}
+
+          git add "operators/paperclip-operator/${VERSION}"
+          git commit -s -m "operator paperclip-operator (${VERSION})"
+          git push --force origin "${BRANCH}"
+
+          # Create PR or update existing one
+          FORK_OWNER=$(gh api user --jq '.login')
+
+          if ! gh pr view "${FORK_OWNER}:${BRANCH}" --repo redhat-openshift-ecosystem/community-operators-prod --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
+            gh pr create \
+              --repo redhat-openshift-ecosystem/community-operators-prod \
               --head "${FORK_OWNER}:${BRANCH}" \
               --title "operator paperclip-operator (${VERSION})" \
               --body "$(cat <<EOF

--- a/bundle/manifests/paperclip-operator.v0.1.0.clusterserviceversion.yaml
+++ b/bundle/manifests/paperclip-operator.v0.1.0.clusterserviceversion.yaml
@@ -302,6 +302,9 @@ spec:
                 serviceAccountName: paperclip-operator-controller-manager
                 terminationGracePeriodSeconds: 10
     strategy: deployment
+  relatedImages:
+    - name: paperclip-operator
+      image: ghcr.io/paperclipinc/paperclip-operator:v0.1.0
   installModes:
     - supported: true
       type: OwnNamespace


### PR DESCRIPTION
## What

Improves the OperatorHub/OLM submission setup three ways:

- **(A) relatedImages** - Adds a top-level `spec.relatedImages` block to the bundle CSV listing the operator image. This lets OLM and disconnected/mirroring tooling discover all images the operator references.
- **(B) Digest pinning** - The `Prepare bundle` step now resolves the published image to an immutable digest via `docker buildx imagetools inspect`, with a safe fallback to the floating tag if resolution fails. The existing image-rewrite sed now substitutes `${IMG_REF}`, so the deployment image, the `containerImage` annotation, and the new `relatedImages` entry are all pinned to the digest (they share one regex).
- **(C) RedHat catalog** - Adds a new `submit-redhat` job mirroring the existing k8s `submit` job, targeting `redhat-openshift-ecosystem/community-operators-prod`. Per RedHat's review model, this job does **not** write a `ci.yaml` (only the k8s job does).

Both jobs are retained in the workflow.

## Validation

- `python3 yaml.safe_load_all` on the workflow: ok
- `relatedImages` parses correctly from the CSV
- `operator-sdk bundle validate ./bundle --select-optional suite=operatorframework`: **All validation tests have completed successfully**
- ASCII-only dash scan: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)